### PR TITLE
Add docker secrets

### DIFF
--- a/examples/workflow.json
+++ b/examples/workflow.json
@@ -5,6 +5,9 @@
     "FirstState": {
       "Type": "Task",
       "Resource": "docker://hello-world:latest",
+      "Credentials": {
+        "mysecret": "dont tell anyone"
+      },
       "Next": "ChoiceState"
     },
     "ChoiceState": {

--- a/lib/manageiq/floe/workflow/runner/docker.rb
+++ b/lib/manageiq/floe/workflow/runner/docker.rb
@@ -3,13 +3,22 @@ module ManageIQ
     class Workflow
       class Runner
         class Docker < ManageIQ::Floe::Workflow::Runner
-          def run!(resource, env = {}, _secrets = {})
-            raise ArgumentError, "Invalid resource" unless resource.start_with?("docker://")
+          def run!(resource, env = {}, secrets = {})
+            raise ArgumentError, "Invalid resource" unless resource&.start_with?("docker://")
 
             image = resource.gsub("docker://", "")
 
+            secrets_file = nil
+
+            if secrets && !secrets.empty?
+              require "tempfile"
+              secrets_file = Tempfile.new
+              secrets_file.write(secrets.to_json)
+            end
+
             params = ["run", :rm]
-            params += env.map { |k, v| [:e, "#{k}=#{v}"] } unless env.empty?
+            params += env.map { |k, v| [:e, "#{k}=#{v}"] } if env && !env.empty?
+            params << [:v, "#{secrets_file.path}:/run/secrets"] if secrets_file
             params << image
 
             require "awesome_spawn"
@@ -17,6 +26,8 @@ module ManageIQ
             result = AwesomeSpawn.run!("docker", :params => params)
 
             [result.exit_status, result.output]
+          ensure
+            File.unlink(secrets_file) if secrets_file
           end
         end
       end

--- a/lib/manageiq/floe/workflow/states/task.rb
+++ b/lib/manageiq/floe/workflow/states/task.rb
@@ -24,7 +24,7 @@ module ManageIQ
             logger.info("Running state: [#{name}]")
 
             runner = ManageIQ::Floe::Workflow::Runner.for_resource(resource)
-            _exit_status, outputs = runner.run!(resource)
+            _exit_status, outputs = runner.run!(resource, parameters, credentials)
 
             next_state = workflow.states_by_name[@next] unless end?
 

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe ManageIQ::Floe::Workflow::Runner::Docker do
+  require "awesome_spawn"
+
+  let(:subject) { described_class.new }
+  let(:result)  { AwesomeSpawn::CommandResult.new(nil, nil, nil, 0) }
+
+  describe "#run!" do
+    it "raises an exception without a resource" do
+      expect { subject.run!(nil) }.to raise_error(ArgumentError, "Invalid resource")
+    end
+
+    it "raises an exception for an invalid resource uri" do
+      expect { subject.run!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
+    end
+
+    it "calls docker run with the image name" do
+      expect(AwesomeSpawn)
+        .to receive(:run!)
+        .with("docker", :params => array_including("run", :rm, "hello-world:latest"))
+        .and_return(result)
+      subject.run!("docker://hello-world:latest")
+    end
+
+    it "passes environment variables to docker run" do
+      expect(AwesomeSpawn)
+        .to receive(:run!)
+        .with("docker", :params => array_including("run", :rm, [:e, "FOO=BAR"], "hello-world:latest"))
+        .and_return(result)
+
+      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
+    end
+
+    it "passes a secrets volume to docker run" do
+      expect(AwesomeSpawn)
+        .to receive(:run!)
+        .with("docker", :params => array_including("run", :rm, [:e, "FOO=BAR"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"))
+        .and_return(result)
+
+      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "1234"})
+    end
+  end
+end


### PR DESCRIPTION
NOTE this implementation uses docker volumes with a tmpfile and thus is not "secure" from other root users on the system, but docker is intended for development purposes only since podman or kubernetes will be used.

Future investigation to see if it is possible to pass a file descriptor (allowing for a hidden secret file) or some other mechanism tot pass docker secrets without requiring docker swarm and without requiring writing secrets to the filesystem.