### PR TITLE
Flush secrets file before mounting to docker volume

### DIFF
--- a/lib/manageiq/floe/workflow/runner/docker.rb
+++ b/lib/manageiq/floe/workflow/runner/docker.rb
@@ -14,6 +14,7 @@ module ManageIQ
               require "tempfile"
               secrets_file = Tempfile.new
               secrets_file.write(secrets.to_json)
+              secrets_file.flush
             end
 
             params = ["run", :rm]
@@ -27,7 +28,7 @@ module ManageIQ
 
             [result.exit_status, result.output]
           ensure
-            File.unlink(secrets_file) if secrets_file
+            secrets_file&.close!
           end
         end
       end


### PR DESCRIPTION
The Docker container was seeing an empty file because the contents were still in buffer cache.