### PR TITLE
Move InputPath/OutputPath to base State

### DIFF
--- a/lib/manageiq/floe/workflow/state.rb
+++ b/lib/manageiq/floe/workflow/state.rb
@@ -42,10 +42,15 @@ module ManageIQ
         def run!(input)
           logger.info("Running state: [#{name}] with input [#{input}]")
 
-          output, next_state = block_given? ? yield : input
+          input = input_path.value(context, input)
+
+          output, next_state = block_given? ? yield(input) : input
           next_state ||= workflow.states_by_name[payload["Next"]] unless end?
 
-          logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}]")
+          output ||= input
+          output   = output_path&.value(context, output)
+
+          logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}] output: [#{output}]")
 
           [next_state, output]
         end

--- a/lib/manageiq/floe/workflow/states/choice.rb
+++ b/lib/manageiq/floe/workflow/states/choice.rb
@@ -17,11 +17,13 @@ module ManageIQ
             @output_path = Path.new(payload.fetch("OutputPath", "$"))
           end
 
-          def run!(input)
-            super do
-              output = input
+          def run!(*)
+            super do |input|
               next_state_name = choices.detect { |choice| choice.true?(context, input) }&.next || default
               next_state      = workflow.states_by_name[next_state_name]
+
+              output = input
+
               [output, next_state]
             end
           end

--- a/lib/manageiq/floe/workflow/states/fail.rb
+++ b/lib/manageiq/floe/workflow/states/fail.rb
@@ -14,6 +14,17 @@ module ManageIQ
             @error = payload["Error"]
           end
 
+          def run!(input)
+            logger.info("Running state: [#{name}] with input [#{input}]")
+
+            next_state = nil
+            output     = input
+
+            logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}]")
+
+            [next_state, output]
+          end
+
           def end?
             true
           end

--- a/lib/manageiq/floe/workflow/states/pass.rb
+++ b/lib/manageiq/floe/workflow/states/pass.rb
@@ -19,8 +19,8 @@ module ManageIQ
             @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
           end
 
-          def run!(input)
-            super do
+          def run!(*)
+            super do |input|
               output = input
               output = result_path.set(output, result) if result && result_path
               output

--- a/lib/manageiq/floe/workflow/states/task.rb
+++ b/lib/manageiq/floe/workflow/states/task.rb
@@ -24,9 +24,8 @@ module ManageIQ
             @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
           end
 
-          def run!(input)
-            super do
-              input = input_path.value(context, input)
+          def run!(*)
+            super do |input|
               input = parameters.value(context, input) if parameters
 
               runner = ManageIQ::Floe::Workflow::Runner.for_resource(resource)
@@ -50,8 +49,7 @@ module ManageIQ
             end
 
             results = result_selector.value(context, results) if result_selector
-            output  = result_path.set(output, results)
-            output_path.value(context, output)
+            result_path.set(output, results)
           end
         end
       end

--- a/lib/manageiq/floe/workflow/states/wait.rb
+++ b/lib/manageiq/floe/workflow/states/wait.rb
@@ -17,11 +17,8 @@ module ManageIQ
             @output_path = Path.new(payload.fetch("OutputPath", "$"), context)
           end
 
-          def run!(input)
-            super do
-              sleep(seconds)
-              input
-            end
+          def run!(*)
+            super { sleep(seconds); nil }
           end
         end
       end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ManageIQ::Floe::Workflow::States::Choice do
-  let(:workflow) { ManageIQ::Floe::Workflow.load(GEM_ROOT.join("examples/workflow.json"), inputs) }
+  let(:workflow) { ManageIQ::Floe::Workflow.load(GEM_ROOT.join("examples/workflow.json")) }
   let(:state)    { workflow.states_by_name["ChoiceState"] }
   let(:inputs)   { {} }
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ManageIQ::Floe::Workflow::States::Task do
-  let(:workflow) { ManageIQ::Floe::Workflow.load(GEM_ROOT.join("examples/workflow.json"), input) }
-  let(:input) { {} }
+  let(:workflow) { ManageIQ::Floe::Workflow.load(GEM_ROOT.join("examples/workflow.json")) }
+  let(:input)    { {} }
 
   describe "#run" do
     let(:mock_runner) { double("ManageIQ::Floe::Workflow::Runner") }
@@ -37,7 +37,7 @@ RSpec.describe ManageIQ::Floe::Workflow::States::Task do
       end
 
       context "with Parameters" do
-        let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Parameters" => {"var1.$" => "$$.foo.bar"}} }
+        let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Parameters" => {"var1.$" => "$.foo.bar"}} }
 
         it "passes the interpolated parameters to the resource" do
           expect(mock_runner)


### PR DESCRIPTION
Every state except for Fail implements InputPath and OutputPath so it makes sense to move this into the base State#run! and override Fail#run! to not process input/output.